### PR TITLE
Added while loop to make sure the app comes up

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -71,7 +71,7 @@ function springBootStop {
 # Check the health of the application
 function validateApp {
   displayMessage "Check application health"
-  pei "http :8080/actuator/health"
+  pei "while ! http :8080/actuator/health 2>/dev/null; do sleep 1; done"
 }
 
 # Display memory usage of the application


### PR DESCRIPTION
In some instances, especially on my older Intel based work macbook, the app doesn't get deployed by the time the default 5 second wait happens.  Using a while loop will retry every one second until `http` returns a successful result.  Stderr is sent to null to not interfere with an error in the middle of the app startup logs and not concern the user with a red error message.

Happy to adjust if necessary but this helps with the random scenarios where the demo was failing.

I'm also aware that you may have other repositories with OpenRewrite demos so for all I know, this may be addressed elsewhere.