### PR TITLE
Add Startup speed percentage improvement to results table

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -186,7 +186,7 @@ function statsSoFarTable {
   printf "%-35s %-25s %-15s %s \n" "Spring Boot 3.2 with AOT, native" "$START3 ($PERCSTART3% faster)" "$MEM3" "$PERC3%"
 
 
-    echo "--------------------------------------------------------------------------------------------"
+  echo "--------------------------------------------------------------------------------------------"
 }
 
 # Display Docker image statistics

--- a/demo.sh
+++ b/demo.sh
@@ -40,7 +40,7 @@ function init {
 function useJava8 {
   displayMessage "Use Java 8, this is for educational purposes only, don't do this at home! (I have jokes.)"
   pei "sdk use java 8.0.392-librca"
-  pei "java -version" 
+  pei "java -version"
 }
 
 # Switch to Java 21 and display version
@@ -151,7 +151,7 @@ function statsSoFar {
   MEM3="$(grep '\S' nativeWith3.2.log2)"
   echo ""
   echo "The Spring Boot 3.2 with Java 21 version is using $(bc <<< "scale=2; ${MEM2}/${MEM1}*100")% of the original footprint"
-  echo "The Spring Boot 3.2 with AOT processing version is using $(bc <<< "scale=2; ${MEM3}/${MEM1}*100")% of the original footprint" 
+  echo "The Spring Boot 3.2 with AOT processing version is using $(bc <<< "scale=2; ${MEM3}/${MEM1}*100")% of the original footprint"
 }
 
 function statsSoFarTable {
@@ -166,21 +166,27 @@ function statsSoFarTable {
   #STARTUP1=$(sed -nE 's/.* in ([0-9]+\.[0-9]+) seconds.*/\1/p' < java8with2.6.log)
   #STARTUP1=$(grep -o 'Started HelloSpringApplication in .*' < java8with2.6.log)
   MEM1=$(cat java8with2.6.log2)
-  printf "%-35s %-25s %-15s %s\n" "Spring Boot 2.6 with Java 8" "$(startupTime 'java8with2.6.log')" "$MEM1" "-"
+  START1=$(startupTime 'java8with2.6.log')
+  printf "%-35s %-25s %-15s %s\n" "Spring Boot 2.7 with Java 8" "$START1" "$MEM1" "-"
 
   # Spring Boot 3.2 with Java 21
   #STARTUP2=$(grep -o 'Started HelloSpringApplication in .*' < java21with3.2.log)
   MEM2=$(cat java21with3.2.log2)
   PERC2=$(bc <<< "scale=2; 100 - ${MEM2}/${MEM1}*100")
-  printf "%-35s %-25s %-15s %s \n" "Spring Boot 3.2 with Java 21" "$(startupTime 'java21with3.2.log')" "$MEM2" "$PERC2%"
+  START2=$(startupTime 'java21with3.2.log')
+  PERCSTART2=$(bc <<< "scale=2; 100 - ${START2}/${START1}*100")
+  printf "%-35s %-25s %-15s %s \n" "Spring Boot 3.2 with Java 21" "$START2 ($PERCSTART2% faster)" "$MEM2" "$PERC2%"
 
   # Spring Boot 3.2 with AOT processing, native image
   #STARTUP3=$(grep -o 'Started HelloSpringApplication in .*' < nativeWith3.2.log)
   MEM3=$(cat nativeWith3.2.log2)
   PERC3=$(bc <<< "scale=2; 100 - ${MEM3}/${MEM1}*100")
-  printf "%-35s %-25s %-15s %s \n" "Spring Boot 3.2 with AOT, native" "$(startupTime 'nativeWith3.2.log')" "$MEM3" "$PERC3%"
+  START3=$(startupTime 'nativeWith3.2.log')
+  PERCSTART3=$(bc <<< "scale=2; 100 - ${START3}/${START1}*100")
+  printf "%-35s %-25s %-15s %s \n" "Spring Boot 3.2 with AOT, native" "$START3 ($PERCSTART3% faster)" "$MEM3" "$PERC3%"
 
-  echo "--------------------------------------------------------------------------------------------"
+
+  echo "--------------------------------------------------------------------------------------------------------------------"
 }
 
 # Display Docker image statistics

--- a/demo.sh
+++ b/demo.sh
@@ -186,7 +186,7 @@ function statsSoFarTable {
   printf "%-35s %-25s %-15s %s \n" "Spring Boot 3.2 with AOT, native" "$START3 ($PERCSTART3% faster)" "$MEM3" "$PERC3%"
 
 
-  echo "--------------------------------------------------------------------------------------------------------------------"
+    echo "--------------------------------------------------------------------------------------------"
 }
 
 # Display Docker image statistics

--- a/demo.sh
+++ b/demo.sh
@@ -71,7 +71,9 @@ function springBootStop {
 # Check the health of the application
 function validateApp {
   displayMessage "Check application health"
-  pei "http :8080/actuator/health"
+  #pei "http :8080/actuator/health"
+  # add loop to recheck if app isn't up yet
+  pei "while ! http :8080/actuator/health 2>/dev/null; do sleep 1; done"
 }
 
 # Display memory usage of the application


### PR DESCRIPTION
In addition to the Memory reduction, there's a huge (94%-96%) improvement in start up time.  Adding this explicitly to the results table to call it out.  