### PR TITLE
Update demo.sh - increase default prompt timeout

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -62,7 +62,7 @@ vendir sync
 . ./vendir/demo-magic/demo-magic.sh
 export TYPE_SPEED=100
 export DEMO_PROMPT="${GREEN}➜ ${CYAN}\W ${COLOR_RESET}"
-PROMPT_TIMEOUT=5
+PROMPT_TIMEOUT=10
 
 
 # Stop ANY & ALL Java Process...they could be Springboot running on our ports!


### PR DESCRIPTION
Did this as a part of session yesterday.

Amazing feedback and everyone loved the demo bit - the counter point was every participant gave the feedback that the demo felt a little too quick.

Setting the default timeout to be a bit longer should be helpful to give a bit more air to breath and explain as we go.